### PR TITLE
Rename `bazel_features.bzlmod` to `bazel_features.external_deps`

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -1,10 +1,10 @@
 load("@bazel_features_globals//:globals.bzl", "globals")
 load("//private:util.bzl", "ge", "gt", "le", "lt", "ne")
 
-_bzlmod = struct(
+_repos = struct(
     # Whether --enable_bzlmod is set, and thus, whether str(Label(...)) produces canonical label
     # literals (i.e., "@@repo//pkg:file").
-    is_enabled = str(Label("//:invalid")).startswith("@@")
+    is_bzlmod_enabled = str(Label("//:invalid")).startswith("@@")
 )
 
 _rules = struct(
@@ -19,8 +19,8 @@ _toolchains = struct(
 )
 
 bazel_features = struct(
-    bzlmod = _bzlmod,
     globals = globals,
+    repos = _repos,
     rules = _rules,
     toolchains = _toolchains,
 )


### PR DESCRIPTION
Continuing the trend of de-emphasizing the name "Bzlmod". I think it would make more sense to group features related to external dependencies together, instead of just Bzlmod features. Not sure whether this should be called `external` or `external_deps` or just `repos`, so I just went with the shortest one.