### PR TITLE
feat: expose a flag name for allow_unresolved_symlinks

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -20,7 +20,7 @@ _flags = struct(
     # This flag was renamed in https://github.com/bazelbuild/bazel/pull/18313
     allow_unresolved_symlinks = (
         "allow_unresolved_symlinks" 
-        if ge("7.0.0")
+        if ge("7.0.0-pre.20230628.2")
         else "experimental_allow_unresolved_symlinks"
     )
 )

--- a/features.bzl
+++ b/features.bzl
@@ -3,6 +3,13 @@
 load("@bazel_features_globals//:globals.bzl", "globals")
 load("//private:util.bzl", "ge")
 
+_allow_unresolved_symlinks_flag = (
+    # This flag was renamed in https://github.com/bazelbuild/bazel/pull/18313
+    "allow_unresolved_symlinks" 
+    if ge("7.0.0")
+    else "experimental_allow_unresolved_symlinks"
+)
+
 _cc = struct(
     # Whether @bazel_tools//tools/cpp:optional_current_cc_toolchain and the `mandatory` parameter
     # on find_cpp_toolchain are available (#17308).
@@ -28,6 +35,7 @@ _toolchains = struct(
 )
 
 bazel_features = struct(
+    allow_unresolved_symlinks_flag = _allow_unresolved_symlinks_flag,
     cc = _cc,
     external_deps = _external_deps,
     globals = globals,

--- a/features.bzl
+++ b/features.bzl
@@ -3,13 +3,6 @@
 load("@bazel_features_globals//:globals.bzl", "globals")
 load("//private:util.bzl", "ge")
 
-_allow_unresolved_symlinks_flag = (
-    # This flag was renamed in https://github.com/bazelbuild/bazel/pull/18313
-    "allow_unresolved_symlinks" 
-    if ge("7.0.0")
-    else "experimental_allow_unresolved_symlinks"
-)
-
 _cc = struct(
     # Whether @bazel_tools//tools/cpp:optional_current_cc_toolchain and the `mandatory` parameter
     # on find_cpp_toolchain are available (#17308).
@@ -21,6 +14,15 @@ _external_deps = struct(
     # Whether --enable_bzlmod is set, and thus, whether str(Label(...)) produces canonical label
     # literals (i.e., "@@repo//pkg:file").
     is_bzlmod_enabled = str(Label("//:invalid")).startswith("@@"),
+)
+
+_flags = struct(
+    # This flag was renamed in https://github.com/bazelbuild/bazel/pull/18313
+    allow_unresolved_symlinks = (
+        "allow_unresolved_symlinks" 
+        if ge("7.0.0")
+        else "experimental_allow_unresolved_symlinks"
+    )
 )
 
 _rules = struct(
@@ -35,9 +37,9 @@ _toolchains = struct(
 )
 
 bazel_features = struct(
-    allow_unresolved_symlinks_flag = _allow_unresolved_symlinks_flag,
     cc = _cc,
     external_deps = _external_deps,
+    flags = _flags,
     globals = globals,
     rules = _rules,
     toolchains = _toolchains,


### PR DESCRIPTION
Allows a principled solution for rules like rules_js that need to have starlark logic conditional on the value, without a breaking change in Bazel 7 as the flag has been renamed.

Unblocks aspect-build/rules_js#1102
Alternative to #14