### PR TITLE
Export .bzl files for Stardoc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,11 @@
+filegroup(
+    name = "bzl_files",
+    srcs = glob(["*.bzl"]) + [
+        "//private:bzl_files",
+        "@bazel_features_globals//:globals.bzl",
+        "@bazel_features_version//:version.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(["features.bzl"])

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "bzl_files",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/private/globals_repo.bzl
+++ b/private/globals_repo.bzl
@@ -1,7 +1,7 @@
 load("//private:parse.bzl", "parse_version")
 
 def _globals_repo_impl(rctx):
-    rctx.file("BUILD.bazel")
+    rctx.file("BUILD.bazel", "exports_files([\"globals.bzl\"])")
 
     bazel_version = parse_version(native.bazel_version)
 

--- a/private/version_repo.bzl
+++ b/private/version_repo.bzl
@@ -1,5 +1,5 @@
 def _version_repo_impl(rctx):
-    rctx.file("BUILD.bazel")
+    rctx.file("BUILD.bazel", "exports_files([\"version.bzl\"])")
     rctx.file("version.bzl", "version = '" + native.bazel_version + "'")
 
 version_repo = repository_rule(_version_repo_impl)


### PR DESCRIPTION
Rulesets that rely on `bazel_features` and also use Stardoc need to provide all `.bzl` files that are transitively loaded to the `stardoc` rule. Since we do not want to add a dependency on `bazel_skylib`, we instead export a `filegroup`.