### PR TITLE
Add a `bazel_feature` to gate the `grep_includes` parameter

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -10,7 +10,7 @@ _cc = struct(
     find_cpp_toolchain_has_mandatory_param = ge("6.1.0"),
     # Note: In Bazel 6.3 the `grep_includes` parameter is optional and a no-op in the cc_common API
     # In future Bazel versions it will be removed altogether.
-    remove_grep_includes_from_api = ge("6.3.0"),
+    grep_includes_is_optional = ge("6.3.0"),
 )
 
 _external_deps = struct(

--- a/features.bzl
+++ b/features.bzl
@@ -8,6 +8,9 @@ _cc = struct(
     # on find_cpp_toolchain are available (#17308).
     # Note: While the target and parameter are available in 6.1.0, they only take effect in Bazel 7.
     find_cpp_toolchain_has_mandatory_param = ge("6.1.0"),
+    # Note: In Bazel 6.3 the `grep_includes` parameter is optional and a no-op in the cc_common API
+    # In future Bazel versions it will be removed altogether.
+    remove_grep_includes_from_api = ge("6.3.0"),
 )
 
 _external_deps = struct(


### PR DESCRIPTION
The `grep_includes` parameter has been made optional in `cc_common` APIs as of Bazel 6.3 (e.g. in https://github.com/bazelbuild/bazel/pull/18823). This feature allows for rulesets to support versions < 6.3, where the `grep_includes` parameter is mandatory, as well as to prepare for future Bazel releases where the `grep_includes` parameter will not exist.