### PR TITLE
Refetch version repositories when Bazel version changes

### DIFF
--- a/private/globals_repo.bzl
+++ b/private/globals_repo.bzl
@@ -19,6 +19,8 @@ def _globals_repo_impl(rctx):
 
 globals_repo = repository_rule(
     _globals_repo_impl,
+    # Force reruns on server restarts to keep native.bazel_version up-to-date.
+    local = True,
     attrs = {
         "globals": attr.string_dict(
             mandatory = True,

--- a/private/version_repo.bzl
+++ b/private/version_repo.bzl
@@ -2,4 +2,8 @@ def _version_repo_impl(rctx):
     rctx.file("BUILD.bazel", "exports_files([\"version.bzl\"])")
     rctx.file("version.bzl", "version = '" + native.bazel_version + "'")
 
-version_repo = repository_rule(_version_repo_impl)
+version_repo = repository_rule(
+    _version_repo_impl,
+    # Force reruns on server restarts to keep native.bazel_version up-to-date.
+    local = True,
+)


### PR DESCRIPTION
Since every version change requires a server restart, it suffices to mark the version-dependent repos as `local`.

Fixes #25