### PR TITLE
feat: add `extract_supports_unicode_filenames`

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -29,6 +29,8 @@ _external_deps = struct(
     download_has_block_param = ge("7.1.0"),
     # Whether repository_ctx#download has the headers parameter, allowing arbitrary headers (#17829)
     download_has_headers_param = ge("7.1.0"),
+    # Whether repository_ctx#extract has unicode filename extraction fix (#18448)
+    extract_supports_unicode_filenames = ge("6.4.0"),
 )
 
 _flags = struct(


### PR DESCRIPTION
A feature gate for https://github.com/bazelbuild/bazel/pull/18448

Required for bazelbuild/rules_go#3872