### PR TITLE
Add `rules.template_dict`

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -50,6 +50,9 @@ _flags = struct(
 )
 
 _rules = struct(
+    # Whether ctx.actions.template_dict and the computed_substitutions parameter of ctx.actions.expand_template are stable.
+    # https://github.com/bazelbuild/bazel/commit/61c31d255b6ba65c372253f65043d6ea3f10e1f9
+    template_dict = ge("7.0.0-pre.20231011.2"),
     # Whether TemplateDict#add_joined allows the map_each callback to return a list of strings (#17306)
     template_dict_map_each_can_return_list = ge("6.1.0"),
     # Whether coverage_common.instrumented_files_info spports the


### PR DESCRIPTION
I named this just `template_dict` rather than `template_dict_is_stable` since the fact that it used to be available earlier as an experimental feature won't be relevant in the future.