### PR TITLE
Use `maybe` in `bazel_features_repo` macro

### DIFF
--- a/private/repos.bzl
+++ b/private/repos.bzl
@@ -3,10 +3,15 @@
 load(":globals.bzl", "GLOBALS")
 load(":globals_repo.bzl", "globals_repo")
 load(":version_repo.bzl", "version_repo")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def bazel_features_repos():
-    version_repo(name = "bazel_features_version")
-    globals_repo(
+    maybe(
+        version_repo,
+        name = "bazel_features_version"
+    )
+    maybe(
+        globals_repo,
         name = "bazel_features_globals",
         globals = GLOBALS,
     )


### PR DESCRIPTION
Makes it easier to include `bazel_features` in `WORKSPACE` projects.