### PR TITLE
Fix "same major version" check logic

### DIFF
--- a/private/util.bzl
+++ b/private/util.bzl
@@ -19,7 +19,8 @@ def ge(v):
 
 def ge_same_major(v):
     pv = parse_version(v)
-    return BAZEL_VERSION >= pv and BAZEL_VERSION[0] == pv[0]
+    # Version 1.2.3 parses to ([1, 2, 3], ...).
+    return BAZEL_VERSION >= pv and BAZEL_VERSION[0][0] == pv[0][0]
 
 def gt(v):
     return BAZEL_VERSION > parse_version(v)


### PR DESCRIPTION
This was introduced in 2db269a, but unintentionally checked for full equality of major, minor and patch version rather than just the major version.