### PR TITLE
Make deps target public

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ bzl_library(
 bzl_library(
     name = "deps",
     srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
         "//private:repos",
         "@bazel_tools//tools/build_defs/repo:http.bzl",


### PR DESCRIPTION
rules_rust depends on this, and our stardoc build is sad if we don't have a dep on it.