### PR TITLE
Revert "chore(deps): update dependency stardoc to v0.7.0 (#61)"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 bazel_dep(
     name = "stardoc",
-    version = "0.7.0",
+    version = "0.6.2",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )


### PR DESCRIPTION
This reverts commit 24fdab748c0fcbffc82e33fbd8f68d4a607cec66.

Stardoc v0.7.0 only supports Bazel 7 and newer, and we test in 6.