### PR TITLE
feat: detect stardoc output change

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -34,8 +34,9 @@ _cc = struct(
 )
 
 _docs = struct(
-    # See https://bazelbuild.slack.com/archives/CDCMRLS23/p1727889648853179?thread_ts=1727887056.727699&cid=CDCMRLS23
-    kwargs_name_with_double_star = gt("8.0.0-pre.20240911.1"),
+    # The stardoc output changed in https://github.com/bazelbuild/bazel/commit/bd1c3af2ea14e81268e940d2b8ba5ad00c3f08d7
+    # This may be required for "diff tests" that assert on the generated API docs.
+    kwargs_name_with_double_star = ge("8.0.0-pre.20240603.2"),
 )
 
 _external_deps = struct(

--- a/features.bzl
+++ b/features.bzl
@@ -1,7 +1,7 @@
 """Defines all the features this module supports detecting."""
 
 load("@bazel_features_globals//:globals.bzl", "globals")
-load("//private:util.bzl", "ge", "ge_same_major", "lt")
+load("//private:util.bzl", "ge", "ge_same_major", "gt", "lt")
 
 _cc = struct(
     # Whether @bazel_tools//tools/cpp:optional_current_cc_toolchain and the `mandatory` parameter
@@ -35,7 +35,7 @@ _cc = struct(
 
 _docs = struct(
     # See https://bazelbuild.slack.com/archives/CDCMRLS23/p1727889648853179?thread_ts=1727887056.727699&cid=CDCMRLS23
-    kwargs_name_with_double_star = ge("8.0.0-pre.20240911.1"),
+    kwargs_name_with_double_star = gt("8.0.0-pre.20240911.1"),
 )
 
 _external_deps = struct(

--- a/features.bzl
+++ b/features.bzl
@@ -33,6 +33,11 @@ _cc = struct(
     protobuf_on_allowlist = ge("8.0.0"),
 )
 
+_docs = struct(
+    # See https://bazelbuild.slack.com/archives/CDCMRLS23/p1727889648853179?thread_ts=1727887056.727699&cid=CDCMRLS23
+    kwargs_name_with_double_star = ge("8.0.0-pre.20240911.1"),
+)
+
 _external_deps = struct(
     # Whether --enable_bzlmod is set, and thus, whether str(Label(...)) produces canonical label
     # literals (i.e., "@@repo//pkg:file").
@@ -98,6 +103,7 @@ _toolchains = struct(
 
 bazel_features = struct(
     cc = _cc,
+    docs = _docs,
     external_deps = _external_deps,
     flags = _flags,
     globals = globals,


### PR DESCRIPTION
Allows Bazel 8 upgrades in rulesets where docgen diff tests otherwise fail, for example https://github.com/aspect-build/rules_lint/pull/401/files