### PR TITLE
Add cc_proto_aspect to globals.bzl

### DIFF
--- a/private/globals.bzl
+++ b/private/globals.bzl
@@ -34,4 +34,5 @@ LEGACY_GLOBALS = {
     "PyCcLinkParamsProvider": "8.0.0",
     "PyInfo": "8.0.0",
     "PyRuntimeInfo": "8.0.0",
+    "cc_proto_aspect": "8.0.0",
 }


### PR DESCRIPTION
Works towards fixing issue reported in https://github.com/protocolbuffers/protobuf/pull/19576

Protobuf at head needs to expose either built-in or Starlark cc_proto_aspect.