### PR TITLE
feat: expose bazel_version

### DIFF
--- a/features.bzl
+++ b/features.bzl
@@ -1,6 +1,7 @@
 """Defines all the features this module supports detecting."""
 
 load("@bazel_features_globals//:globals.bzl", "globals")
+load("@bazel_features_version//:version.bzl", _bazel_version = "version")
 load("//private:util.bzl", "ge", "ge_same_major", "gt", "lt")
 
 _apple = struct(
@@ -163,3 +164,7 @@ bazel_features = struct(
     rules = _rules,
     toolchains = _toolchains,
 )
+
+# Expose a public API providing the version of Bazel.
+# Workaround for https://github.com/bazelbuild/bazel/issues/8305
+bazel_version = _bazel_version


### PR DESCRIPTION
It's a fair amount of code that wires up the version here. See https://github.com/bazelbuild/bazel/issues/8305#issuecomment-1954690199 for a published workaround, but it's not complete due to subtleties like https://github.com/bazel-contrib/bazel_features/issues/25

In my opinion the maintenance burden of bazel_features exposing this one string is worth it to avoid other rules like bazelrc-preset.bzl having to copy dozens of lines of code.