### PR TITLE
Fix prerelease identifier precedence

### DIFF
--- a/private/parse.bzl
+++ b/private/parse.bzl
@@ -14,6 +14,19 @@ def _partition(s):
             return s[:i], s[i:]
     return s, ""
 
+def _parse_prerelease(prerelease):
+    # Parses a SemVer prerelease string into a list of comparable identifiers, following the
+    # precedence rules at https://semver.org/#spec-item-11.
+    if not prerelease:
+        return []
+    identifiers = []
+    for ident in prerelease.split("."):
+        if ident.isdigit():
+            identifiers.append((0, int(ident)))
+        else:
+            identifiers.append((1, ident))
+    return identifiers
+
 def parse_version(v):
     """Parses the given Bazel version string into a comparable value.
 
@@ -35,4 +48,4 @@ def parse_version(v):
         # feature detection. This allows for realistic testing of candidates and avoids the need to
         # specify "rc1" on every version.
         prerelease = ""
-    return [_safe_int(s, v) for s in segments], not prerelease, prerelease
+    return [_safe_int(s, v) for s in segments], not prerelease, _parse_prerelease(prerelease)

--- a/test/test.bzl
+++ b/test/test.bzl
@@ -28,6 +28,14 @@ def run_test(name):
     _assert_lt("6.0.0-pre.20241105.2", "6.0.0-pre.20241113.4")
     _assert_lt("6.0.0 some build metadata", "6.1.0 some other build metadata")
     _assert_lt("6.0.0", "")
+    _assert_lt("1.0.0-alpha", "1.0.0-alpha.1")
+    _assert_lt("1.0.0-alpha.1", "1.0.0-alpha.beta")
+    _assert_lt("1.0.0-alpha.beta", "1.0.0-beta")
+    _assert_lt("1.0.0-beta", "1.0.0-beta.2")
+    _assert_lt("1.0.0-beta.2", "1.0.0-beta.11")
+    _assert_lt("1.0.0-beta.11", "1.0.0-rc.1")
+    _assert_lt("1.0.0-rc.1", "1.0.0")
+    _assert_lt("10.0.0-pre.20260524.1", "10.0.0-pre-db077161e43484e4cb0f2270374ee33d05f3690d")
 
     # a smoke test on the actual current Bazel version
     if not ge("0.0.1"):


### PR DESCRIPTION
Before this commit bazel_features compared prerelease identifiers as strings, resulting in incorrect precedence between rolling releases and last_green builds.