### PR TITLE
Drop dev version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,5 @@
 module(
     name = "bazel_features",
-    version = "0.0.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.6.1")


### PR DESCRIPTION
The empty versions sorts highest, which is correct for the in-tree state.